### PR TITLE
replaced join() by join('') to avoid extra comma's

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@ export default class BrowserMobProxyAPIClient {
           const data: string[] = [];
           res.on('data', chunk => data.push(chunk));
           res.on('end', () => {
-            resolve(data.join());
+            resolve(data.join(''));
           });
         });
 


### PR DESCRIPTION
For very long HAR-files, comma's were added, making the JSON invalid. This could be traced to this call of join() (the default separator is a comma, rather than the empty string).