### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,6 @@ jobs:
           PROXY_HOST: proxy
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           files: ./coverage/clover.xml


### PR DESCRIPTION
Reverts raul72/browsermob-proxy-api-client#61

**Upload coverage to Codecov**
```
Run codecov/codecov-action@v[4](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:5)
/usr/bin/docker exec  e22[5](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:6)501530f8c0d9108[6](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:7)2abccb32ece9bdde5b9b2967df1ffee2bf4575ba5433 sh -c "cat /etc/*release | grep ^ID"
==> linux OS detected
https://cli.codecov.io/latest/linux/codecov.SHA256SUM
==> SHASUM file signed by key id 806bb28aed[7](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:8)79[8](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:9)6[9](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:10)
==> Uploader SHASUM verified (e826f8190b81889e9d567264c1a7945d6f8b541dc9d7a0696905901a6aacd5f9  codecov)
==> Running version latest
==> Running version v0.6.2
==> Running command '/__w/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/__w/_actions/codecov/codecov-action/v4/dist/codecov create-commit
[199] Error loading Python lib '/tmp/_MEIRkhU3R/libpython3.[10](https://github.com/raul72/browsermob-proxy-api-client/actions/runs/6188530733/job/16800825138#step:6:11).so.1.0': dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /tmp/_MEIRkhU3R/libpython3.10.so.1.0)
Warning: Codecov: Failed to properly create commit: The process '/__w/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 255
```