### PR TITLE
Enable binary content tests

### DIFF
--- a/test/startHarAndGetHar.test.ts
+++ b/test/startHarAndGetHar.test.ts
@@ -327,7 +327,6 @@ describe('startHarAndGetHar', () => {
     }
   });
 
-  /**
   test('HAR not to contain binary content by default', async () => {
     const API = new BrowserMobProxyAPIClient(PROXY_API_HOST, PROXY_API_PORT);
     const port = Number(await API.start());
@@ -461,7 +460,6 @@ describe('startHarAndGetHar', () => {
       await API.stop(Number(port));
     }
   });
-  */
 
   test('HAR to contain set initialPageTitle', async () => {
     const API = new BrowserMobProxyAPIClient(PROXY_API_HOST, PROXY_API_PORT);


### PR DESCRIPTION
Re-enable unit tests
- HAR not to contain binary content by default
- HAR to contain binary content when requested
- HAR to contain set initialPageRef

resolves https://github.com/raul72/browsermob-proxy-api-client/issues/5